### PR TITLE
Fix YouTube duration parsing

### DIFF
--- a/src/services/youtubeService.ts
+++ b/src/services/youtubeService.ts
@@ -5,7 +5,7 @@ export interface VideosResponse {
   nextPageToken?: string;
 }
 
-const DURATION_REGEX = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/;
+const DURATION_REGEX = /PT(?:(?<H>\d+)H)?(?:(?<M>\d+)M)?(?:(?<S>\d+)S)?/;
 const CACHE_KEY = "yt_v3_cache";
 const CACHE_TTL = 14400000;
 const API_ENDPOINTS = {


### PR DESCRIPTION
## Summary
- fix regex for parsing ISO8601 durations in `youtubeService`

## Testing
- `npm run lint` *(fails: 12 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840abd4f0388326ad7e19840afd1510