### PR TITLE
Add config saving feature to SpaceCalc

### DIFF
--- a/src/pages/SpaceCalcPage.tsx
+++ b/src/pages/SpaceCalcPage.tsx
@@ -670,7 +670,7 @@ const SpaceCalcPage: React.FC = () => {
                 placeholder="Ex: Cargo léger"
               />
             </div>
-            <button type="button" className="save-btn" onClick={saveCurrentConfig}">Sauvegarder</button>
+            <button type="button" className="save-btn" onClick={saveCurrentConfig}>Sauvegarder</button>
             <button type="submit" className="calculate-btn">Calculer</button>
             <button type="button" className="reset-btn" onClick={resetConfig}>Reset</button>
           </form>

--- a/src/pages/SpaceCalcPage.tsx
+++ b/src/pages/SpaceCalcPage.tsx
@@ -245,6 +245,7 @@ const SpaceCalcPage: React.FC = () => {
   });
   const [batteryExplanation, setBatteryExplanation] = useState<string>("");
   const [savedConfigs, setSavedConfigs] = useState<SavedConfig[]>([]);
+  const [configName, setConfigName] = useState<string>("");
   const [theme] = useState<'retro' | 'modern'>('retro');
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -302,6 +303,27 @@ const SpaceCalcPage: React.FC = () => {
     const newConfigs = savedConfigs.filter(config => config.id !== id);
     setSavedConfigs(newConfigs);
     localStorage.setItem('spacecalc-configs', JSON.stringify(newConfigs));
+  };
+
+  const saveCurrentConfig = () => {
+    if (!configName.trim()) return;
+    const newConfig: SavedConfig = {
+      id: crypto.randomUUID(),
+      name: configName.trim(),
+      shipSize,
+      weight,
+      gravity,
+      atmosphere,
+      multiplier,
+      thrusterType: vehicleType === 'atmospheric' ? 'atmospheric' : 'interplanetary',
+      batteryType: 'auto',
+      systemMargin,
+      targetAutonomy
+    };
+    const newConfigs = [...savedConfigs, newConfig];
+    setSavedConfigs(newConfigs);
+    localStorage.setItem('spacecalc-configs', JSON.stringify(newConfigs));
+    setConfigName('');
   };
 
   const calculateAxisCombination = (
@@ -638,6 +660,17 @@ const SpaceCalcPage: React.FC = () => {
                 ))}
               </select>
             </div>
+            <div className="input-group">
+              <label htmlFor="configName">Nom de la Configuration</label>
+              <input
+                type="text"
+                id="configName"
+                value={configName}
+                onChange={(e) => setConfigName(e.target.value)}
+                placeholder="Ex: Cargo léger"
+              />
+            </div>
+            <button type="button" className="save-btn" onClick={saveCurrentConfig}">Sauvegarder</button>
             <button type="submit" className="calculate-btn">Calculer</button>
             <button type="button" className="reset-btn" onClick={resetConfig}>Reset</button>
           </form>

--- a/src/styles/pages/SpaceCalc.css
+++ b/src/styles/pages/SpaceCalc.css
@@ -215,6 +215,23 @@ input[type="range"]::-moz-range-thumb {
   border-color: var(--color-accent);
 }
 
+/* Bouton Sauvegarder */
+.save-btn {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  background: var(--color-accent-dark);
+  color: #ffffff;
+  border: none;
+  border-radius: var(--border-radius-sm);
+  font-family: 'Courier New', monospace;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.save-btn:hover {
+  background: var(--color-accent);
+}
+
 /* Résultats et cartes */
 .results-section {
   display: grid;


### PR DESCRIPTION
## Summary
- add state to hold config name
- implement `saveCurrentConfig` to persist current settings
- expose input field and save button in SpaceCalc form
- style new save button

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b8319ce48326aceb1216c987c100