### PR TITLE
Add config import to SpaceCalc

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ Le projet nécessite les configurations suivantes:
 - Configuration des services de news
 - Paramètres de connexion aux réseaux sociaux
 
+## 📤 Export/Import SpaceCalc
+
+L'outil **SpaceCalc** permet d'exporter vos calculs sous forme de fichier JSON. Ce fichier suit la structure suivante :
+
+```json
+{
+  "configuration": {
+    "shipSize": "small",
+    "baseWeight": 10000,
+    "gravity": "earth",
+    "atmosphere": "normal",
+    "multiplier": "realistic"
+  },
+  "containerStats": { /* ... */ },
+  "thrusterResults": { /* ... */ },
+  "multiAxisConfig": { /* ... */ },
+  "timestamp": "2024-01-01T12:00:00Z",
+  "version": "1.0.0"
+}
+```
+
+Pour réimporter une configuration, cliquez sur le bouton **Importer** dans la section d'export de SpaceCalc et sélectionnez votre fichier `.json`. Les valeurs de configuration (taille du vaisseau, masse, environnement...) seront chargées automatiquement ainsi que les résultats associés.
+
 ## 🤝 Contribution
 
 Les contributions sont les bienvenues! Voici comment participer:

--- a/src/pages/SpaceCalcPage.tsx
+++ b/src/pages/SpaceCalcPage.tsx
@@ -518,6 +518,31 @@ const SpaceCalcPage: React.FC = () => {
     document.body.removeChild(aElem);
   };
 
+  const importConfig = (file: File): void => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const text = e.target?.result as string;
+        const data: ExportData = JSON.parse(text);
+        const cfg = data.configuration;
+        setShipSize(cfg.shipSize);
+        setWeight(cfg.baseWeight.toString());
+        setGravity(cfg.gravity);
+        setAtmosphere(cfg.atmosphere);
+        setMultiplier(cfg.multiplier);
+        setVehicleType(cfg.vehicleType);
+        setSystemMargin(cfg.systemMargin);
+        setTargetAutonomy(cfg.targetAutonomy);
+        setContainerStats(data.containerStats);
+        setResults(data.thrusterResults);
+        setMultiAxisResults(data.multiAxisConfig);
+      } catch (err) {
+        console.error('Import failed', err);
+      }
+    };
+    reader.readAsText(file);
+  };
+
   return (
     <div className={`spacecalc-container ${theme}`}>
       {savedConfigs.length > 0 && (
@@ -649,6 +674,18 @@ const SpaceCalcPage: React.FC = () => {
               <pre style={{ whiteSpace: 'pre-wrap' }}>{generateSummary()}</pre>
             </div>
             <div className="export-section">
+              <input
+                id="importFile"
+                type="file"
+                accept="application/json"
+                style={{ display: 'none' }}
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) importConfig(file);
+                  e.target.value = '';
+                }}
+              />
+              <label htmlFor="importFile" className="import-btn">Importer</label>
               <button className="export-btn" onClick={exportResults} title="Exporter les résultats en JSON">
                 Exporter les Résultats
               </button>

--- a/src/styles/pages/SpaceCalc.css
+++ b/src/styles/pages/SpaceCalc.css
@@ -876,6 +876,7 @@ input[type="range"]::-moz-range-thumb {
   display: flex;
   justify-content: flex-end;
 }
+.import-btn,
 .export-btn {
   background: linear-gradient(135deg, #2c3e50, #3498db);
   color: #ffffff;
@@ -893,6 +894,7 @@ input[type="range"]::-moz-range-thumb {
   position: relative;
   overflow: hidden;
 }
+.import-btn::before,
 .export-btn::before {
   content: '';
   position: absolute;
@@ -904,13 +906,16 @@ input[type="range"]::-moz-range-thumb {
   opacity: 0;
   transition: opacity 0.2s ease;
 }
+.import-btn:hover::before,
 .export-btn:hover::before {
   opacity: 1;
 }
+.import-btn:hover,
 .export-btn:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0,0,0,0.3);
 }
+.import-btn:active,
 .export-btn:active {
   transform: translateY(0);
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
@@ -1158,6 +1163,7 @@ input[type="range"]::-moz-range-thumb {
   display: flex;
   justify-content: flex-end;
 }
+.import-btn,
 .export-btn {
   background: linear-gradient(135deg, #2c3e50, #3498db);
   color: #ffffff;
@@ -1175,6 +1181,7 @@ input[type="range"]::-moz-range-thumb {
   position: relative;
   overflow: hidden;
 }
+.import-btn::before,
 .export-btn::before {
   content: '';
   position: absolute;
@@ -1186,13 +1193,16 @@ input[type="range"]::-moz-range-thumb {
   opacity: 0;
   transition: opacity 0.2s ease;
 }
+.import-btn:hover::before,
 .export-btn:hover::before {
   opacity: 1;
 }
+.import-btn:hover,
 .export-btn:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0,0,0,0.3);
 }
+.import-btn:active,
 .export-btn:active {
   transform: translateY(0);
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);


### PR DESCRIPTION
## Summary
- add `importConfig` to read JSON exports in SpaceCalc
- provide Import button in export section
- style new button
- document import/export procedure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b83e3768832681feb3901760f63b