### PR TITLE
Add ore selection for container calc

### DIFF
--- a/src/config/thrustersData.ts
+++ b/src/config/thrustersData.ts
@@ -331,7 +331,41 @@ export const itemData: Record<string, ItemData> = {
         mass: 1.0,
         volume: 0.37
     },
-    // ... autres items ...
+    "DisplayName_Item_IronOre": {
+        name: "Iron Ore",
+        type: "Ore",
+        subtype: "Iron",
+        mass: 3.0,
+        volume: 0.37
+    },
+    "DisplayName_Item_GoldOre": {
+        name: "Gold Ore",
+        type: "Ore",
+        subtype: "Gold",
+        mass: 4.0,
+        volume: 0.37
+    },
+    "DisplayName_Item_UraniumOre": {
+        name: "Uranium Ore",
+        type: "Ore",
+        subtype: "Uranium",
+        mass: 7.0,
+        volume: 0.37
+    },
+    "DisplayName_Item_IronIngot": {
+        name: "Iron Ingot",
+        type: "Ingot",
+        subtype: "Iron",
+        mass: 0.37,
+        volume: 0.127
+    },
+    "DisplayName_Item_GoldIngot": {
+        name: "Gold Ingot",
+        type: "Ingot",
+        subtype: "Gold",
+        mass: 0.52,
+        volume: 0.065
+    },
     "DisplayName_Item_UraniumIngot": {
         name: "Uranium Ingot",
         type: "Ingot",
@@ -369,6 +403,24 @@ export const ores: Record<string, OreData> = {
         mass: 7.8,
         volume: 0.37,
         baseValue: 100
+    },
+    stone: {
+        name: "Pierre",
+        mass: 2.7,
+        volume: 0.37,
+        baseValue: 10
+    },
+    uranium: {
+        name: "Minerai d'Uranium",
+        mass: 19.0,
+        volume: 0.37,
+        baseValue: 500
+    },
+    gold: {
+        name: "Minerai d'Or",
+        mass: 5.0,
+        volume: 0.37,
+        baseValue: 200
     }
 };
 

--- a/src/pages/SpaceCalcPage.tsx
+++ b/src/pages/SpaceCalcPage.tsx
@@ -1,36 +1,22 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  gravityOptions, 
+import {
+  gravityOptions,
   atmosphereOptions,
   containerMultiplierOptions,
   smallShipThrusters,
   largeShipThrusters,
-  smallShipCargo,
-  largeShipCargo,
   ThrusterData,
   batteries,
   ores
 } from '../config/thrustersData';
+import { calculateContainerStats, ContainerConfig as CargoConfig, ContainerStats } from '../utils/containerStats';
 import '../styles/pages/SpaceCalc.css';
 
 type VehicleType = 'atmospheric' | 'interplanetary';
 
-interface ContainerConfig {
-  small: number;
-  medium: number;
-  large: number;
-  isFilled: boolean;
-}
-
 interface CalculationResults {
   requiredThrust: number;
-  containerStats: {
-    totalMass: number;
-    totalVolume: number;
-    emptyMass: number;
-    maxCapacity: number;
-    fillStatus: string;
-  };
+  containerStats: ContainerStats;
   batteryRequirements: {
     count: number;
     optimalCount: number;
@@ -57,13 +43,6 @@ interface SavedConfig {
   targetAutonomy: number;
 }
 
-interface ContainerStats {
-  totalMass: number;
-  totalVolume: number;
-  emptyMass: number;
-  maxCapacity: number;
-  fillStatus: string;
-}
 
 interface AxisConfiguration {
   direction: string;
@@ -228,11 +207,13 @@ const SpaceCalcPage: React.FC = () => {
   // Fusion des paramètres en un unique facteur de marge (en %)
   const [systemMargin, setSystemMargin] = useState<number>(100);
   const [targetAutonomy, setTargetAutonomy] = useState<number>(1);
-  const [containers, setContainers] = useState<ContainerConfig>({
+  const [containers, setContainers] = useState<CargoConfig>({
     small: 0,
     medium: 0,
     large: 0,
-    isFilled: false
+    isFilled: false,
+    oreType: 'iron',
+    customDensity: 0
   });
   const [results, setResults] = useState<CalculationResults | null>(null);
   const [multiAxisResults, setMultiAxisResults] = useState<MultiAxisResults | null>(null);
@@ -247,21 +228,9 @@ const SpaceCalcPage: React.FC = () => {
   const [savedConfigs, setSavedConfigs] = useState<SavedConfig[]>([]);
   const [theme] = useState<'retro' | 'modern'>('retro');
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const calculateContainerStats = (): ContainerStats => {
-    const cargoData = shipSize === 'small' ? smallShipCargo : largeShipCargo;
-    let totalVolume = 0, emptyMass = 0, maxCapacity = 0;
-    Object.entries(containers).forEach(([size, value]) => {
-      if (size !== 'isFilled' && cargoData[size]) {
-        const count = Number(value);
-        emptyMass += cargoData[size].mass * count;
-        totalVolume += cargoData[size].volume * count;
-        maxCapacity += cargoData[size].volume * count * 7.8;
-      }
-    });
-    const totalMass = containers.isFilled ? emptyMass + (totalVolume * ores.iron.mass) : emptyMass;
-    return { totalMass, totalVolume, emptyMass, maxCapacity, fillStatus: containers.isFilled ? 'Remplis de minerai de fer' : 'Vides' };
-  };
+  const getContainerStats = React.useCallback((): ContainerStats => {
+    return calculateContainerStats(shipSize, containers);
+  }, [shipSize, containers]);
 
   useEffect(() => {
     const saved = localStorage.getItem('spacecalc-configs');
@@ -269,21 +238,21 @@ const SpaceCalcPage: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    const stats = calculateContainerStats();
+    const stats = getContainerStats();
     setContainerStats(stats);
-  }, [calculateContainerStats, containers, shipSize]);
+  }, [getContainerStats, containers, shipSize]);
 
   const resetConfig = () => {
     setWeight('');
     setSystemMargin(100);
     setTargetAutonomy(1);
-    setContainers({ small: 0, medium: 0, large: 0, isFilled: false });
+    setContainers({ small: 0, medium: 0, large: 0, isFilled: false, oreType: 'iron', customDensity: 0 });
     setResults(null);
     setMultiAxisResults(null);
     setBatteryExplanation("");
   };
 
-  const updateContainer = (key: keyof ContainerConfig, value: number | boolean) => {
+  const updateContainer = (key: keyof CargoConfig, value: number | boolean | string) => {
     setContainers(prev => ({ ...prev, [key]: value }));
   };
 
@@ -315,7 +284,7 @@ const SpaceCalcPage: React.FC = () => {
 
   const calculateThrusters = (e: React.FormEvent): void => {
     e.preventDefault();
-    const stats = calculateContainerStats();
+    const stats = getContainerStats();
     setContainerStats(stats);
     const baseWeight = parseFloat(weight);
     const totalWeight = baseWeight + stats.totalMass;
@@ -579,6 +548,20 @@ const SpaceCalcPage: React.FC = () => {
                     Remplir les Conteneurs
                   </label>
                 </div>
+                {containers.isFilled && (
+                  <div className="container-input">
+                    <label>Contenu</label>
+                    <select value={containers.oreType} onChange={(e) => updateContainer('oreType', e.target.value)}>
+                      {Object.entries(ores).map(([key, ore]) => (
+                        <option key={key} value={key}>{ore.name}</option>
+                      ))}
+                      <option value="custom">Personnalisé</option>
+                    </select>
+                    {containers.oreType === 'custom' && (
+                      <input type="number" placeholder="kg/L" value={containers.customDensity} onChange={(e) => updateContainer('customDensity', parseFloat(e.target.value) || 0)} />
+                    )}
+                  </div>
+                )}
               </div>
               <div className="container-stats">
                 <div className="container-stats-item">

--- a/src/utils/__tests__/containerStats.test.ts
+++ b/src/utils/__tests__/containerStats.test.ts
@@ -1,0 +1,29 @@
+import { calculateContainerStats, ContainerConfig } from '../containerStats';
+
+const baseConfig: ContainerConfig = {
+  small: 0,
+  medium: 0,
+  large: 1,
+  isFilled: true,
+  oreType: 'iron',
+  customDensity: 0,
+};
+
+describe('calculateContainerStats', () => {
+  test('calculates mass with iron ore', () => {
+    const stats = calculateContainerStats('small', baseConfig);
+    expect(Math.round(stats.totalMass)).toBe(Math.round(626.2 + 15625 * 7.8));
+  });
+
+  test('calculates mass with stone ore', () => {
+    const config = { ...baseConfig, oreType: 'stone' };
+    const stats = calculateContainerStats('small', config);
+    expect(Math.round(stats.totalMass)).toBe(Math.round(626.2 + 15625 * 2.7));
+  });
+
+  test('calculates mass with custom density', () => {
+    const config = { ...baseConfig, oreType: 'custom', customDensity: 10 };
+    const stats = calculateContainerStats('small', config);
+    expect(Math.round(stats.totalMass)).toBe(Math.round(626.2 + 15625 * 10));
+  });
+});

--- a/src/utils/containerStats.ts
+++ b/src/utils/containerStats.ts
@@ -1,0 +1,46 @@
+import { smallShipCargo, largeShipCargo, ores } from '../config/thrustersData';
+
+export interface ContainerConfig {
+  small: number;
+  medium: number;
+  large: number;
+  isFilled: boolean;
+  oreType: string;
+  customDensity: number;
+}
+
+export interface ContainerStats {
+  totalMass: number;
+  totalVolume: number;
+  emptyMass: number;
+  maxCapacity: number;
+  fillStatus: string;
+}
+
+export function calculateContainerStats(shipSize: 'small' | 'large', containers: ContainerConfig): ContainerStats {
+  const cargoData = shipSize === 'small' ? smallShipCargo : largeShipCargo;
+  let totalVolume = 0;
+  let emptyMass = 0;
+  let maxCapacity = 0;
+
+  (['small', 'medium', 'large'] as const).forEach(size => {
+    const count = Number(containers[size] || 0);
+    const data = (cargoData as any)[size];
+    if (data) {
+      emptyMass += data.mass * count;
+      totalVolume += data.volume * count;
+      maxCapacity += data.volume * count * 7.8;
+    }
+  });
+
+  const density = containers.oreType === 'custom'
+    ? containers.customDensity || 0
+    : ores[containers.oreType]?.mass ?? ores.iron.mass;
+
+  const totalMass = containers.isFilled ? emptyMass + totalVolume * density : emptyMass;
+  const fillStatus = containers.isFilled
+    ? `Remplis de ${containers.oreType === 'custom' ? 'contenu personnalisé' : ores[containers.oreType]?.name ?? 'minerai'}`
+    : 'Vides';
+
+  return { totalMass, totalVolume, emptyMass, maxCapacity, fillStatus };
+}


### PR DESCRIPTION
## Summary
- support several ores and ingots in config
- compute container mass using selected ore type or custom density
- expose new util for container mass calculations
- update SpaceCalc page with ore selector and custom mass field
- add unit tests for container mass calculation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b84af0988326a2e9db2cb4ecfcf7