### PR TITLE
Add Mod Manager tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ L'outil **SpaceCalc** permet d'exporter vos calculs sous forme de fichier JSON. 
 
 Pour réimporter une configuration, cliquez sur le bouton **Importer** dans la section d'export de SpaceCalc et sélectionnez votre fichier `.json`. Les valeurs de configuration (taille du vaisseau, masse, environnement...) seront chargées automatiquement ainsi que les résultats associés.
 
+## 🧩 Mod Manager
+
+Ce nouvel outil permettra de gérer vos listes de mods Space Engineers.
+Inspiré par [Space-Engineers-Mod-Manager](https://github.com/g3arshift/Space-Engineers-Mod-Manager),
+il offrira l'import/export de modlists et la détection de conflits.
+
 ## 🤝 Contribution
 
 Les contributions sont les bienvenues! Voici comment participer:

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,12 @@
+# Tâches pour l'implémentation du Mod Manager
+
+1. **Ajouter la page Mod Manager**
+   - Créer `ModManagerPage.tsx` avec un composant de base.
+   - Ajouter la route `/tools/modmanager` dans `src/App.tsx`.
+   - Insérer la carte correspondante dans `ToolsPage.tsx`.
+2. **Intégrer la gestion des modlists**
+   - S'appuyer sur l'outil open source [Space-Engineers-Mod-Manager](https://github.com/g3arshift/Space-Engineers-Mod-Manager) pour permettre l'import/export de listes de mods.
+   - Prévoir l'organisation et le tri des mods (ordre de chargement, thèmes, etc.).
+3. **Suivi des conflits entre mods**
+   - Implémenter un système d'analyse des incompatibilités (feature planifiée dans le Mod Manager).
+   - Afficher des alertes claires pour les utilisateurs.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,18 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import { Navbar } from './components/Navbar'
-import { Hero } from './components/Hero'
-import { CommunityGallery } from './components/CommunityGallery'
-import { ArticlePage } from './components/ArticlePage'
-import { Footer } from './components/Footer'
-import { OpenSourceBanner } from './components/OpenSourceBanner'
-import SpaceflixPage from './pages/SpaceflixPage'
-import ToolsPage from './pages/ToolsPage'
-import SpaceCalcPage from './pages/SpaceCalcPage'
-import VideoPage from './pages/VideoPage'
-import CommunityPage from './pages/CommunityPage'
-import './styles/App.css'
-import React from 'react'
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Navbar } from './components/Navbar';
+import { Hero } from './components/Hero';
+import { CommunityGallery } from './components/CommunityGallery';
+import { ArticlePage } from './components/ArticlePage';
+import { Footer } from './components/Footer';
+import { OpenSourceBanner } from './components/OpenSourceBanner';
+import SpaceflixPage from './pages/SpaceflixPage';
+import ToolsPage from './pages/ToolsPage';
+import SpaceCalcPage from './pages/SpaceCalcPage';
+import ModManagerPage from './pages/ModManagerPage';
+import VideoPage from './pages/VideoPage';
+import CommunityPage from './pages/CommunityPage';
+import './styles/App.css';
+import React from 'react';
 
 const HomePage: React.FC = () => (
   <main>
@@ -19,7 +20,7 @@ const HomePage: React.FC = () => (
     <OpenSourceBanner />
     <section className="social-section" id="social-section"></section>
   </main>
-)
+);
 
 const App: React.FC = () => (
   <BrowserRouter>
@@ -33,10 +34,12 @@ const App: React.FC = () => (
         <Route path="/video/:videoId" element={<VideoPage />} />
         <Route path="/tools" element={<ToolsPage />} />
         <Route path="/tools/spacecalc" element={<SpaceCalcPage />} />
+        <Route path="/tools/modmanager" element={<ModManagerPage />} />
         <Route path="/community" element={<CommunityPage />} />
       </Routes>
       <Footer />
     </div>
   </BrowserRouter>
-)
-export default App
+);
+
+export default App;

--- a/src/pages/ModManagerPage.tsx
+++ b/src/pages/ModManagerPage.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import '../styles/pages/ModManager.css';
+
+const ModManagerPage: React.FC = () => (
+  <main className="mod-manager-container">
+    <h1>Mod Manager</h1>
+    <p>
+      Cet outil permettra de gérer vos listes de mods Space Engineers : import,
+      export et organisation avancée.
+    </p>
+    <p>Fonctionnalités détaillées à venir.</p>
+  </main>
+);
+
+export default ModManagerPage;

--- a/src/pages/ToolsPage.tsx
+++ b/src/pages/ToolsPage.tsx
@@ -49,6 +49,17 @@ const tools: ToolCard[] = [
     progress: 0,
     status: 'Planifié',
     githubUrl: 'https://github.com/engineers-hub/PowerGrid'
+  },
+  {
+    title: 'Mod Manager',
+    description: 'Gérez vos mods Space Engineers et partagez vos modlists',
+    path: '/tools/modmanager',
+    icon: '🧩',
+    tags: ['Mods', 'Gestion'],
+    creator: '@SE2HubTeam',
+    progress: 10,
+    status: 'Planifié',
+    githubUrl: 'https://github.com/g3arshift/Space-Engineers-Mod-Manager'
   }
 ];
 

--- a/src/styles/pages/ModManager.css
+++ b/src/styles/pages/ModManager.css
@@ -1,0 +1,4 @@
+.mod-manager-container {
+  padding: 2rem;
+  color: var(--color-text);
+}

--- a/src/styles/pages/Tools.css
+++ b/src/styles/pages/Tools.css
@@ -167,8 +167,9 @@
   /* Fond de carte distinct selon le data-tool, si besoin */
   .tool-card[data-tool="SpaceCalc"]::before,
   .tool-card[data-tool="ResourceTracker"]::before,
-  .tool-card[data-tool="PowerGrid"]::before {
-    content: '';
+  .tool-card[data-tool="PowerGrid"]::before,
+  .tool-card[data-tool="Mod Manager"]::before {
+    content: "";
     position: absolute;
     inset: 0;
     background-size: cover;


### PR DESCRIPTION
## Summary
- add a placeholder Mod Manager page and CSS
- link new route in `App.tsx`
- list Mod Manager card in `ToolsPage`
- style support for Mod Manager in Tools.css
- document Mod Manager in README
- add tasks in `TASKS.md`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c4178cb483268810cd6bb4bbe797