### PR TITLE
Add Mod Manager tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ L'outil **SpaceCalc** permet d'exporter vos calculs sous forme de fichier JSON. 
 
 Pour réimporter une configuration, cliquez sur le bouton **Importer** dans la section d'export de SpaceCalc et sélectionnez votre fichier `.json`. Les valeurs de configuration (taille du vaisseau, masse, environnement...) seront chargées automatiquement ainsi que les résultats associés.
 
+## 🧩 Mod Manager
+
+Ce nouvel outil permet désormais d'éditer simplement vos listes de mods Space Engineers.
+Inspiré par [Space-Engineers-Mod-Manager](https://github.com/g3arshift/Space-Engineers-Mod-Manager),
+il offre l'import/export de modlists et la détection de conflits (fonctionnalité planifiée).
+Vous pouvez ajouter ou supprimer des mods, sauvegarder la liste dans le navigateur et exporter un fichier `modlist.json`.
+Depuis cette version, un champ de recherche permet de trouver un mod directement via le Workshop Steam.
+Les résultats s'affichent sous la barre de recherche et vous pouvez ajouter un mod en un clic sans retenir son identifiant.
+
 ## 🤝 Contribution
 
 Les contributions sont les bienvenues! Voici comment participer:

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,22 @@
+# Tâches pour l'implémentation du Mod Manager
+
+1. **Ajouter la page Mod Manager**
+   - Créer `ModManagerPage.tsx` avec un composant de base.
+   - Ajouter la route `/tools/modmanager` dans `src/App.tsx`.
+   - Insérer la carte correspondante dans `ToolsPage.tsx`.
+2. **Intégrer la gestion des modlists**
+   - S'appuyer sur l'outil open source [Space-Engineers-Mod-Manager](https://github.com/g3arshift/Space-Engineers-Mod-Manager) pour permettre l'import/export de listes de mods.
+   - Prévoir l'organisation et le tri des mods (ordre de chargement, thèmes, etc.).
+3. **Suivi des conflits entre mods**
+   - Implémenter un système d'analyse des incompatibilités (feature planifiée dans le Mod Manager).
+   - Afficher des alertes claires pour les utilisateurs.
+4. **Interface d'édition**
+   - Permettre l'ajout et la suppression de mods manuellement.
+   - Sauvegarder la liste localement dans le navigateur.
+5. **Import/Export simplifié**
+   - Importer une `modlist.json` depuis un fichier.
+   - Exporter la liste actuelle au même format.
+6. **Recherche de mods intégrée**
+   - Ajouter l'endpoint `/api/mods/search` dans `server.js` pour interroger le Workshop Steam et retourner une liste de mods (id, nom, miniature).
+   - Afficher un champ de recherche dans `ModManagerPage` et présenter les résultats sous forme de liste.
+   - Permettre l'ajout direct d'un mod depuis les résultats sans avoir à saisir son identifiant manuellement.

--- a/server.js
+++ b/server.js
@@ -73,6 +73,39 @@ app.get('/api/news', async (req, res) => {
   }
 });
 
+// Recherche de mods sur le Workshop Steam
+app.get('/api/mods/search', async (req, res) => {
+  const query = req.query.q;
+  if (!query || typeof query !== 'string') {
+    return res.status(400).json({ error: 'Paramètre q manquant' });
+  }
+
+  try {
+    const searchUrl = `https://steamcommunity.com/workshop/browse/?appid=244850&searchtext=${encodeURIComponent(
+      query
+    )}&numperpage=10`;
+    const response = await axios.get(searchUrl);
+    const $ = cheerio.load(response.data);
+    const mods = [];
+
+    $('.workshopItem').each((_, el) => {
+      const link = $(el).find('a.ugc').attr('href');
+      const idMatch = link && link.match(/\?id=(\d+)/);
+      const id = idMatch ? idMatch[1] : null;
+      const name = $(el).find('.workshopItemTitle').text().trim();
+      const image = $(el).find('.workshopItemPreviewImage').attr('src');
+      if (id) {
+        mods.push({ id, name, image });
+      }
+    });
+
+    res.json({ mods });
+  } catch (error) {
+    console.error('Erreur lors de la recherche de mods:', error.message);
+    res.status(500).json({ error: 'Échec de la récupération des mods' });
+  }
+});
+
 app.listen(PORT, () => {
   console.log(`Serveur démarré sur http://localhost:${PORT}`);
 }); 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,18 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import { Navbar } from './components/Navbar'
-import { Hero } from './components/Hero'
-import { CommunityGallery } from './components/CommunityGallery'
-import { ArticlePage } from './components/ArticlePage'
-import { Footer } from './components/Footer'
-import { OpenSourceBanner } from './components/OpenSourceBanner'
-import SpaceflixPage from './pages/SpaceflixPage'
-import ToolsPage from './pages/ToolsPage'
-import SpaceCalcPage from './pages/SpaceCalcPage'
-import VideoPage from './pages/VideoPage'
-import CommunityPage from './pages/CommunityPage'
-import './styles/App.css'
-import React from 'react'
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Navbar } from './components/Navbar';
+import { Hero } from './components/Hero';
+import { CommunityGallery } from './components/CommunityGallery';
+import { ArticlePage } from './components/ArticlePage';
+import { Footer } from './components/Footer';
+import { OpenSourceBanner } from './components/OpenSourceBanner';
+import SpaceflixPage from './pages/SpaceflixPage';
+import ToolsPage from './pages/ToolsPage';
+import SpaceCalcPage from './pages/SpaceCalcPage';
+import ModManagerPage from './pages/ModManagerPage';
+import VideoPage from './pages/VideoPage';
+import CommunityPage from './pages/CommunityPage';
+import './styles/App.css';
+import React from 'react';
 
 const HomePage: React.FC = () => (
   <main>
@@ -19,7 +20,7 @@ const HomePage: React.FC = () => (
     <OpenSourceBanner />
     <section className="social-section" id="social-section"></section>
   </main>
-)
+);
 
 const App: React.FC = () => (
   <BrowserRouter>
@@ -33,10 +34,12 @@ const App: React.FC = () => (
         <Route path="/video/:videoId" element={<VideoPage />} />
         <Route path="/tools" element={<ToolsPage />} />
         <Route path="/tools/spacecalc" element={<SpaceCalcPage />} />
+        <Route path="/tools/modmanager" element={<ModManagerPage />} />
         <Route path="/community" element={<CommunityPage />} />
       </Routes>
       <Footer />
     </div>
   </BrowserRouter>
-)
-export default App
+);
+
+export default App;

--- a/src/pages/ModManagerPage.tsx
+++ b/src/pages/ModManagerPage.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useRef, useState } from 'react';
+import '../styles/pages/ModManager.css';
+
+interface ModEntry {
+  id: string;
+  name: string;
+}
+
+const STORAGE_KEY = 'se2hub-modlist';
+
+const ModManagerPage: React.FC = () => {
+  const [mods, setMods] = useState<ModEntry[]>([]);
+  const [modId, setModId] = useState('');
+  const [modName, setModName] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<ModEntry[]>([]);
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      try {
+        setMods(JSON.parse(saved));
+      } catch {
+        setMods([]);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mods));
+  }, [mods]);
+
+  const addMod = (id?: string, name?: string): void => {
+    const finalId = id || modId;
+    const finalName = name || modName;
+    if (!finalId || !finalName) return;
+    if (mods.some((m) => m.id === finalId)) return;
+    setMods([...mods, { id: finalId, name: finalName }]);
+    setModId('');
+    setModName('');
+    setSearchQuery('');
+    setSearchResults([]);
+  };
+
+  const removeMod = (id: string): void => {
+    setMods(mods.filter((m) => m.id !== id));
+  };
+
+  const importMods = (file: File): void => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const json = JSON.parse(e.target?.result as string);
+        if (Array.isArray(json.mods)) {
+          setMods(json.mods.map((m: any) => ({ id: String(m.id), name: String(m.name) })));
+        }
+      } catch (err) {
+        console.error('Import failed', err);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const handleImport = (): void => {
+    const file = fileInput.current?.files?.[0];
+    if (file) importMods(file);
+  };
+
+  const searchMods = async (query: string): Promise<void> => {
+    if (!query) {
+      setSearchResults([]);
+      return;
+    }
+    try {
+      const resp = await fetch(`/api/mods/search?q=${encodeURIComponent(query)}`);
+      const data = await resp.json();
+      if (Array.isArray(data.mods)) {
+        setSearchResults(data.mods);
+      }
+    } catch (err) {
+      console.error('Search failed', err);
+    }
+  };
+
+  const exportMods = (): void => {
+    const data = { mods };
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json'
+    });
+    const url = window.URL.createObjectURL(blob);
+    const aElem = document.createElement('a');
+    aElem.href = url;
+    aElem.download = 'modlist.json';
+    document.body.appendChild(aElem);
+    aElem.click();
+    window.URL.revokeObjectURL(url);
+    document.body.removeChild(aElem);
+  };
+
+  return (
+    <main className="mod-manager-container">
+      <h1>Mod Manager</h1>
+      <p>Gérez, importez et exportez vos modlists Space Engineers.</p>
+
+      <div className="search-box">
+        <label htmlFor="modSearch">Rechercher un mod</label>
+        <input
+          id="modSearch"
+          value={searchQuery}
+          onChange={(e) => {
+            setSearchQuery(e.target.value);
+            searchMods(e.target.value);
+          }}
+          placeholder="Nom du mod"
+        />
+      </div>
+
+      {searchResults.length > 0 && (
+        <ul className="search-results">
+          {searchResults.map((res) => (
+            <li key={res.id} className="search-item">
+              {res.image && (
+                <img src={res.image} alt="" aria-hidden="true" />
+              )}
+              <span>{res.name}</span>
+              <button
+                type="button"
+                onClick={() => addMod(res.id, res.name)}
+              >
+                Ajouter
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mod-form">
+        <div className="input-group">
+          <label htmlFor="modId">ID du mod</label>
+          <input
+            id="modId"
+            value={modId}
+            onChange={(e) => setModId(e.target.value)}
+            placeholder="123456789"
+          />
+        </div>
+        <div className="input-group">
+          <label htmlFor="modName">Nom</label>
+          <input
+            id="modName"
+            value={modName}
+            onChange={(e) => setModName(e.target.value)}
+            placeholder="Nom du mod"
+          />
+        </div>
+        <button className="add-mod-btn" onClick={addMod} type="button">
+          Ajouter
+        </button>
+      </div>
+
+      {mods.length > 0 && (
+        <ul className="mod-list">
+          {mods.map((mod) => (
+            <li key={mod.id} className="mod-item">
+              <span className="mod-id">{mod.id}</span>
+              <span className="mod-name">{mod.name}</span>
+              <button
+                className="delete-mod-btn"
+                onClick={() => removeMod(mod.id)}
+                aria-label={`Supprimer ${mod.name}`}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mod-actions">
+        <input
+          type="file"
+          ref={fileInput}
+          accept="application/json"
+          onChange={handleImport}
+          aria-label="Importer une modlist"
+        />
+        <button className="export-mods-btn" onClick={exportMods} type="button">
+          Exporter
+        </button>
+      </div>
+    </main>
+  );
+};
+
+export default ModManagerPage;

--- a/src/pages/ModManagerPage.tsx
+++ b/src/pages/ModManagerPage.tsx
@@ -75,9 +75,20 @@ const ModManagerPage: React.FC = () => {
     }
     try {
       const resp = await fetch(`/api/mods/search?q=${encodeURIComponent(query)}`);
-      const data = await resp.json();
-      if (Array.isArray(data.mods)) {
-        setSearchResults(data.mods);
+      if (!resp.ok) {
+        throw new Error(`HTTP ${resp.status}`);
+      }
+      const contentType = resp.headers.get('content-type') || '';
+      const text = await resp.text();
+      if (contentType.includes('application/json')) {
+        const data = JSON.parse(text);
+        if (Array.isArray(data.mods)) {
+          setSearchResults(data.mods);
+        } else {
+          setSearchResults([]);
+        }
+      } else {
+        console.error('Unexpected response', text.slice(0, 100));
       }
     } catch (err) {
       console.error('Search failed', err);

--- a/src/pages/ModManagerPage.tsx
+++ b/src/pages/ModManagerPage.tsx
@@ -4,6 +4,7 @@ import '../styles/pages/ModManager.css';
 interface ModEntry {
   id: string;
   name: string;
+  image?: string;
 }
 
 const STORAGE_KEY = 'se2hub-modlist';
@@ -154,7 +155,7 @@ const ModManagerPage: React.FC = () => {
             placeholder="Nom du mod"
           />
         </div>
-        <button className="add-mod-btn" onClick={addMod} type="button">
+        <button className="add-mod-btn" onClick={() => addMod()} type="button">
           Ajouter
         </button>
       </div>

--- a/src/pages/ToolsPage.tsx
+++ b/src/pages/ToolsPage.tsx
@@ -49,6 +49,17 @@ const tools: ToolCard[] = [
     progress: 0,
     status: 'Planifié',
     githubUrl: 'https://github.com/engineers-hub/PowerGrid'
+  },
+  {
+    title: 'Mod Manager',
+    description: 'Gérez vos mods Space Engineers et partagez vos modlists',
+    path: '/tools/modmanager',
+    icon: '🧩',
+    tags: ['Mods', 'Gestion'],
+    creator: '@SE2HubTeam',
+    progress: 10,
+    status: 'Planifié',
+    githubUrl: 'https://github.com/g3arshift/Space-Engineers-Mod-Manager'
   }
 ];
 

--- a/src/styles/pages/ModManager.css
+++ b/src/styles/pages/ModManager.css
@@ -1,0 +1,90 @@
+.mod-manager-container {
+  padding: 2rem;
+  color: var(--color-text);
+}
+
+.mod-form {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.add-mod-btn {
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.mod-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem 0;
+}
+
+.mod-item {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.delete-mod-btn {
+  margin-left: auto;
+  background: transparent;
+  color: var(--color-text);
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+}
+
+.mod-actions {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.export-mods-btn {
+  background: linear-gradient(135deg, #2c3e50, #3498db);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.search-box {
+  margin-bottom: 1rem;
+}
+
+.search-results {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem 0;
+}
+
+.search-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+}
+
+.search-item img {
+  width: 32px;
+  height: 32px;
+}
+
+.search-item button {
+  margin-left: auto;
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/src/styles/pages/Tools.css
+++ b/src/styles/pages/Tools.css
@@ -167,8 +167,9 @@
   /* Fond de carte distinct selon le data-tool, si besoin */
   .tool-card[data-tool="SpaceCalc"]::before,
   .tool-card[data-tool="ResourceTracker"]::before,
-  .tool-card[data-tool="PowerGrid"]::before {
-    content: '';
+  .tool-card[data-tool="PowerGrid"]::before,
+  .tool-card[data-tool="Mod Manager"]::before {
+    content: "";
     position: absolute;
     inset: 0;
     background-size: cover;


### PR DESCRIPTION
## Summary
- add a placeholder Mod Manager page and CSS
- link new route in `App.tsx`
- list Mod Manager card in `ToolsPage`
- style support for Mod Manager in Tools.css
- document Mod Manager in README
- add tasks in `TASKS.md`


------
https://chatgpt.com/codex/tasks/task_e_6840c4178cb483268810cd6bb4bbe797